### PR TITLE
fix bug: #43 and #75 on make.py and added ta reset command

### DIFF
--- a/lib/cli_displayed/dis_cli.py
+++ b/lib/cli_displayed/dis_cli.py
@@ -1,3 +1,19 @@
+"""
+Display typo
+
+============
+
+A simple function to displayed the working process to user.
+You should use this function on every process on this program to be the standard of this project.
+
+Limitations
+-----------
+This function can display maximum of 2 line first is main line and second is optional line.
+And the typo is depend on the boolean variable, so it have only 2 typo [/] and [x]
+
+
+"""
+
 # private
 def _display_order(order):
     if order > 0:
@@ -10,19 +26,74 @@ def _display_order(order):
         order = ""
     return order
 
-def _massage_func(typo,massage,order):
-    return f"{_display_order(order)}[{typo}] {massage}"
+def _message_func(typo,message,order):
+    return f"{_display_order(order)}[{typo}] {message}"
 
 
 # public
-def display_typo(order,func,massage,optional_massage="",when=False):
+def display_typo(order,func,message,optional_message="",when=False):
+    """
+    Use this function for displayed process on user screen
+
+    Args:
+        order (int): 
+            order the position in line
+            [0]
+                [1]
+                    [2] . . .
+
+        func (bool): 
+            boolean to tell that it's pass or not
+
+        message (str): 
+            string to displayed to the user screen
+            [?] <message>
+
+        optional_message (str): Defaults to ""
+            if this include it will displayed in order+1 position
+            [?] <main message>
+                [*] <optional message>
+
+        when (bool): Defaults to False.
+            if this var is equal to `func` optional message will be displayed
+    
+    Notes
+    -----
+    you can pass function that return boolean into func 
+
+    =========
+    def func1():
+        return False
+
+    >>> display_typo(0,func1(),"message")
+    ... [x] message
+    =========
+
+    example
+    -------
+
+    >>> display_typo(0,True,"message")
+    ... [/] message
+
+    >>> display_typo(0,False,"message")
+    ... [x] message
+
+    >>> display_typo(0,True,"message","optional_message",when=True)
+    ... [/] message
+    ... |-[*] optional_message
+
+    >>> display_typo(0,True,"message","optional_message",when=False)
+    ... [/] message
+
+            
+    """
     typo = func
     if typo:
-        print(_massage_func("/",massage,order))
+        print(_message_func("/",message,order))
     else:
-        print(_massage_func("x",massage,order))
-    if optional_massage != "":
+        print(_message_func("x",message,order))
+    if optional_message != "":
         if typo == when:
-            print(_massage_func("*",optional_massage,order+1))
+            print(_message_func("*",optional_message,order+1))
 
 

--- a/src/build/make.py
+++ b/src/build/make.py
@@ -8,6 +8,7 @@ from lib.function_network import CallApi, SaveApiKey
 
 
 # private
+
 def _create_ta_dir(path):
     ta_path = os.path.join(path, "ta")
     if os.path.exists(ta_path):
@@ -19,7 +20,8 @@ def _create_ta_dir(path):
 
 def _check_config(workid, path):
     config_path = os.path.join(path, "ta", "config.json")
-    if os.path.exists(config_path):
+    draft_path = os.path.join(path, "ta", "draft.json")
+    if os.path.exists(config_path) and os.path.exists(draft_path):
         return False
     else:
         ConfigEditor(workid, path).writeconfig()
@@ -44,17 +46,23 @@ def _fetch_api_massage(apiobj):
 
 
 # public
+
 def init_work_directory(path, workid) -> bool:
     config_path = os.path.join(path, "ta", "config.json")
     ta_path = os.path.join(path, "ta")
     draft_path = os.path.join(path, "ta", "draft.json")
 
     keystate = _check_api_key(path)
-
+    
     print(f"[*] {path} makeing work directory")
     display_typo(1,_create_ta_dir(path),f"Creating workDirectory {path}",
                 optional_massage="Skipped. Already exists",when=False)
-    display_typo(1,_check_config(workid, path),"Creating `config.json`",
+    configstate = _check_config(workid, path)
+    if not configstate:
+        print("[x] Initialize Error")
+        print("     <Please delete a ta directory or `ta reset` and try again.>")
+        return False
+    display_typo(1,configstate,"Creating `config.json`",
                 optional_massage="Skipped. Already exists",when=False)
     display_typo(1,keystate,"Checking API-KEY",
                 optional_massage="API-KEY doesn't exists",when=False)

--- a/ta_cli/cli.py
+++ b/ta_cli/cli.py
@@ -76,8 +76,9 @@ def submit():
 
 @cli.command()
 def reset():
+    """Delete ta folder"""
     if os.path.exists(os.path.join(current_dir, "ta")):
         make.reset(current_dir)
-        """Delete ta folder"""
+        
     else:
         print("You don't have ta directory.")

--- a/ta_cli/cli.py
+++ b/ta_cli/cli.py
@@ -72,3 +72,9 @@ def submit():
         SendData(current_dir)
     else:
         print("You don't have work.json to submit")
+@cli.command()
+def reset():
+    if os.path.exists(os.path.join(current_dir,"ta")):
+        make.reset(current_dir)
+    else:
+        print("You don't have ta directory.")

--- a/ta_cli/cli.py
+++ b/ta_cli/cli.py
@@ -68,13 +68,16 @@ def fetch():
 @cli.command()
 def submit():
     """Submit"""
-    if os.path.exists(os.path.join(current_dir,"ta","work.json")):
+    if os.path.exists(os.path.join(current_dir, "ta", "work.json")):
         SendData(current_dir)
     else:
         print("You don't have work.json to submit")
+
+
 @cli.command()
 def reset():
-    if os.path.exists(os.path.join(current_dir,"ta")):
+    if os.path.exists(os.path.join(current_dir, "ta")):
         make.reset(current_dir)
+        """Delete ta folder"""
     else:
         print("You don't have ta directory.")


### PR DESCRIPTION
### Description
Bug fixed
#43 
#75 
Handle when user want to initialize but ta directory is already create.
If it have only config.json user can use` ta init` and config.json will be change.
But if it have config.json and draft.json user can't `use ta init` so it will return error message to user.
(need to delete ta directory before try again)

New:
- add ` ta reset` : delete ta directory
### Checklist
- [ ] All tests passing
- [ ] #43 
- [ ] #75 
